### PR TITLE
Bug fix to EventDetailsActivity

### DIFF
--- a/app/src/main/java/com/example/circleapp/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/circleapp/EventDetailsActivity.java
@@ -16,7 +16,7 @@ public class EventDetailsActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.event_details_activity);
 
-        Event event = (Event) getIntent().getSerializableExtra("event");
+        Event event = (Event) getIntent().getParcelableExtra("event");
 
         TextView eventNameTextView = findViewById(R.id.event_details_name);
         TextView eventLocationTextView = findViewById(R.id.event_details_location);


### PR DESCRIPTION
Changed event from serializable to parcelable in EventDetailsActivity to remain consistent with last change to Event class.

This fixes the bug of the app crashing when an event is clicked to view event details